### PR TITLE
Use _ for the Ghostty cursor

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,4 +1,6 @@
 background-blur = true
 background-opacity = 0.75
+cursor-style = underline
+shell-integration-features = no-cursor
 window-padding-x = 4
 window-padding-y = 4

--- a/vimrc
+++ b/vimrc
@@ -33,6 +33,9 @@ highlight Pmenu ctermbg=238 gui=bold
 " Setup ignore patterns for CommandT
 set wildignore+=*.o,*.obj,.git,doc/**,*.sql,*.log
 
+" Reset cursor on exit so terminal picks up Ghostty's cursor-style
+autocmd VimLeave * silent !echo -ne "\e[0 q"
+
 " Add spell check and maxium text width to git commits
 autocmd FileType gitcommit setlocal spell
 autocmd FileType gitcommit setlocal textwidth=72


### PR DESCRIPTION
Update Ghostty config to use the underline cursor style, and update vim to reset the cursor on exit or it stops blinking.