### PR TITLE
Tune Starship directory icon substitutions

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -63,11 +63,13 @@ format = "[ $path ]($style)"
 # similar to mapped_locations in Oh My Posh:
 [directory.substitutions]
 ".dotfiles" = " "
-"Code" = "󰈮 "
-"Documents" = "󰈙 "
-"Downloads" = " "
-"Music" = " "
-"Pictures" = " "
+"~/Code" = "󰈮 "
+"~/Desktop" = "󰧨 "
+"~/Documents" = "󰈙 "
+"~/Downloads" = " "
+"~/Music" = " "
+"~/Pictures" = " "
+"~" = "󰋜 "
 # Keep in mind that the order matters. For example:
 # "Important Documents" = " 󰈙 "
 # will not be replaced, because "Documents" was already substituted before.


### PR DESCRIPTION
Update the directory substitutions to include the home path (i.e., ~/Code instead of Code) so it gets replaced with the icon, too.

Also add icons for ~/Desktop and ~/ (i.e., home).