### PR TITLE
Add Ruby lang/version support to the prompt

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -24,6 +24,7 @@ $java\
 $julia\
 $nodejs\
 $nim\
+$ruby\
 $rust\
 $scala\
 [](fg:#86BBD8 bg:#06969A)\
@@ -162,24 +163,41 @@ format = '[ ♥ $time ]($style)'
 
 [package]
 symbol = "󰏗 "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [perl]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [php]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [pijul_channel]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [pixi]
 symbol = "󰏗 "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [python]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [rlang]
 symbol = "󰟔 "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
 
 [ruby]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+


### PR DESCRIPTION
Update the prompt to show the Ruby version for Ruby projects, and ensure the correct style is rendered for all supported languages.